### PR TITLE
ログイン後の購入画面の商品表示以外を実装

### DIFF
--- a/React/src/App.tsx
+++ b/React/src/App.tsx
@@ -1,33 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import Routes from './Routes'
+import { useRoutes } from "react-router-dom";
 
 function App() {
-  const [count, setCount] = useState(0)
+  const routing = useRoutes(Routes)
 
   return (
     <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      {routing}
     </>
   )
 }

--- a/React/src/Routes.tsx
+++ b/React/src/Routes.tsx
@@ -1,0 +1,14 @@
+import { RouteObject } from "react-router-dom";
+import LoginPage from "./pages/LoginPage";
+import PurchasePage from "./pages/PurchasePage";
+
+const Routes: RouteObject[] = [
+  {
+    children: [
+        { path: "/", element: <LoginPage /> },
+        { path: "/purchase", element: <PurchasePage /> },
+    ],
+  },
+];
+
+export default Routes;

--- a/React/src/components/GroupSelect.tsx
+++ b/React/src/components/GroupSelect.tsx
@@ -1,0 +1,26 @@
+import { Tabs, TabList, TabPanels, Tab, TabPanel } from "@chakra-ui/react";
+
+const GroupSelect = () => {
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>319</Tab>
+        <Tab>324</Tab>
+        <Tab>405</Tab>
+      </TabList>
+
+      {/* <TabPanels>
+        <TabPanel>
+          <p>one!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>two!</p>
+        </TabPanel>
+        <TabPanel>
+          <p>three!</p>
+        </TabPanel>
+      </TabPanels> */}
+    </Tabs>
+  );
+};
+export default GroupSelect;

--- a/React/src/components/LoginContent.tsx
+++ b/React/src/components/LoginContent.tsx
@@ -1,0 +1,29 @@
+import { Input, InputGroup, InputRightElement, Button } from "@chakra-ui/react";
+import { useState } from "react";
+
+const LoginContent = () => {
+  const [show, setShow] = useState(false);
+  const handleClick = () => setShow(!show);
+
+  return (
+    <>
+      <Input placeholder="User name" mb="5" />
+
+      <InputGroup size="md" mb="10">
+        <Input
+          pr="4.5rem"
+          type={show ? "text" : "password"}
+          placeholder="Enter password"
+        />
+        <InputRightElement width="4.5rem">
+          <Button h="1.75rem" size="sm" onClick={handleClick}>
+            {show ? "Hide" : "Show"}
+          </Button>
+        </InputRightElement>
+      </InputGroup>
+
+      <Button colorScheme='blue'>Login</Button>
+    </>
+  );
+};
+export default LoginContent;

--- a/React/src/components/PurchaseConfirm.tsx
+++ b/React/src/components/PurchaseConfirm.tsx
@@ -1,0 +1,41 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+} from "@chakra-ui/react";
+import { useDisclosure } from "@chakra-ui/react";
+
+const PurchaseConfirm = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  return (
+    <>
+      <Button onClick={onOpen} colorScheme='blue' mt="20">購入</Button>
+      
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>購入確認</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <p>購入しますか？</p>
+            <p>---購入内容表示---</p>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button variant="ghost" mr={3} onClick={onClose}>
+              キャンセル
+            </Button>
+            <Button colorScheme="blue">購入確定</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+export default PurchaseConfirm;

--- a/React/src/main.tsx
+++ b/React/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 import { ChakraProvider } from '@chakra-ui/react'
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ChakraProvider>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ChakraProvider>
   </React.StrictMode>,
 )

--- a/React/src/pages/LoginPage.tsx
+++ b/React/src/pages/LoginPage.tsx
@@ -1,0 +1,14 @@
+import LoginContent from "../components/LoginContent";
+import { Box } from '@chakra-ui/react'
+
+const LoginPage = () => {
+  return (
+    <>
+			<Box>
+      	<LoginContent />
+			</Box>
+    </>
+  );
+};
+
+export default LoginPage;

--- a/React/src/pages/PurchasePage.tsx
+++ b/React/src/pages/PurchasePage.tsx
@@ -1,11 +1,11 @@
 import GroupSelect from "../components/GroupSelect"
-import { Button } from '@chakra-ui/react'
+import PurchaseConfirm from "../components/PurchaseConfirm"
 
 const PurchasePage = () => {
   return (
     <>
       <GroupSelect />
-      <Button colorScheme='blue' mt="20">購入</Button>
+      <PurchaseConfirm />
     </>
   )
 }

--- a/React/src/pages/PurchasePage.tsx
+++ b/React/src/pages/PurchasePage.tsx
@@ -1,0 +1,12 @@
+import GroupSelect from "../components/GroupSelect"
+import { Button } from '@chakra-ui/react'
+
+const PurchasePage = () => {
+  return (
+    <>
+      <GroupSelect />
+      <Button colorScheme='blue' mt="20">購入</Button>
+    </>
+  )
+}
+export default PurchasePage


### PR DESCRIPTION
### feature/7
ログイン後の購入画面のうち、商品表示以外の部分を実装しました。モーダルの関係で、購入確認画面も表示されます。
せっかくだったのでログイン画面も実装しました。

#### 確認方法
```
cd React
npm run dev
```
"http://localhost:5173/" にアクセスするとログイン画面が、"http://localhost:5173/purchase" にアクセスするとログイン後の画面が表示されます。