### PR TITLE
ReactのDockerによる起動

### DIFF
--- a/Docker/backend/Dockerfile
+++ b/Docker/backend/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir --upgrade -r /backend/requirements.txt
 COPY /FastAPI/run.py /backend/
 COPY /FastAPI/.env /backend/
 
-CMD ["uvicorn", "run:app", "--reload", "--host", "0.0.0.0", "--port", "3001"]
+CMD ["uvicorn", "run:app", "--reload", "--host", "0.0.0.0", "--port", "8000"]

--- a/Docker/frontend/Dockerfile
+++ b/Docker/frontend/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /frontend
 COPY /React/.eslintrc.cjs .
 COPY /React/index.html .
 COPY /React/package.json .
-COPY /React/package-lock.json .
 COPY /React/vite.config.ts .
 COPY /React/tsconfig.json .
 COPY /React/tsconfig.node.json .

--- a/Docker/frontend/Dockerfile
+++ b/Docker/frontend/Dockerfile
@@ -4,7 +4,4 @@ WORKDIR /frontend
 COPY /React/package.json .
 RUN npm install
 
-COPY /React/src /frontend/src/
-COPY /React/public /frontend/public/
-
-CMD ["npm", "start"]
+CMD ["npm", "run", "dev"]

--- a/Docker/frontend/Dockerfile
+++ b/Docker/frontend/Dockerfile
@@ -1,7 +1,14 @@
 FROM node:latest
 WORKDIR /frontend
 
+COPY /React/.eslintrc.cjs .
+COPY /React/index.html .
 COPY /React/package.json .
+COPY /React/package-lock.json .
+COPY /React/vite.config.ts .
+COPY /React/tsconfig.json .
+COPY /React/tsconfig.node.json .
+
 RUN npm install
 
 CMD ["npm", "run", "dev"]

--- a/FastAPI/run.py
+++ b/FastAPI/run.py
@@ -10,7 +10,9 @@ app = FastAPI()
 
 origins = [
     "http://localhost:3000",
+    "http://127.0.0.1:3000",
     "http://localhost:5173",
+    "http://127.0.0.1:5173",
 ]
 
 app.add_middleware(

--- a/React/vite.config.ts
+++ b/React/vite.config.ts
@@ -3,5 +3,9 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    host: true
+  },
+  
   plugins: [react()],
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,7 @@ services:
     build:
       context: .
       dockerfile: Docker/frontend/Dockerfile
+    volumes:
+      - ./React:/frontend
     ports:
-      - 3000:3000
+      - 3000:5173

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       context: .
       dockerfile: Docker/frontend/Dockerfile
     volumes:
-      - ./React:/frontend
+      - ./React/src:/frontend/src
+      - ./React/public:/frontend/public
     ports:
       - 3000:5173

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ./FastAPI/services:/backend/services
 
     ports:
-      - 3001:3001
+      - 8000:8000
   
   frontend:
     build:


### PR DESCRIPTION
issue #57 

現在Reactがdocker composeで立ち上がらないので、それを解消した。
また、ReactとFastAPIが通信できることを確認した。